### PR TITLE
[feature] xbd 유사 인스턴스 분할 추론용 모델 서빙 구현 #1

### DIFF
--- a/xbd/app.py
+++ b/xbd/app.py
@@ -1,1 +1,46 @@
-# app.py
+import nest_asyncio
+import uvicorn
+import secrets
+from fastapi import FastAPI, UploadFile, HTTPException, status
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from PIL import Image as PILImage
+from pyngrok import ngrok
+from pydantic import BaseModel
+from typing import List, Tuple, Dict, Any
+
+# Copy paste https://github.com/sibas-lab/segmentation-model/blob/90ec79852720da8bd49fcfcb62b3acf55a96d07c/xbd/inference.py
+
+ngrok.set_auth_token(userdata.get('NGROK_AUTH_TOKEN'))
+
+class HealthResult(BaseModel):
+  isAlive: bool
+
+class PredictionResponse(BaseModel):
+  status: str
+  message: str
+  instance_detected: int
+  instances: list[Instance]
+
+app = FastAPI()
+
+app.mount("/static", StaticFiles(directory="/content/result_img"), name="static")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=['*'],
+    allow_credentials=True,
+    allow_methods=['*'],
+    allow_headers=['*'],
+)
+
+@app.get("/health")
+async def get_health() -> HealthResult:
+    return HealthResult(isAlive=True)
+
+ngrok_tunnel = ngrok.connect(8000)
+print('공용 URL:', ngrok_tunnel.public_url)
+nest_asyncio.apply()
+uvicorn.run(app, port=8000)
+
+# ngrok.kill()


### PR DESCRIPTION
API 명세서: 해당 프로젝트를 코랩에서 실행하면 배포된 주소의 `/docs` 링크에 있습니다.

.ipynb 파일은 트렐로 카드에서 확인할 수 있습니다.

<img width="937" alt="스크린샷 2024-07-15 15 35 21" src="https://github.com/user-attachments/assets/6dfd883c-0948-47f1-8fa4-79bc219f1663">
<img width="976" alt="스크린샷 2024-07-15 15 25 25" src="https://github.com/user-attachments/assets/b673dcb8-970b-4959-befe-0a7968016ac6">
<img width="949" alt="스크린샷 2024-07-15 15 25 36" src="https://github.com/user-attachments/assets/5dd078ec-dbb4-4fa4-90da-d4c51de3df79">
